### PR TITLE
chore: restrict claude

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "deny": [
+      "Read(**/.env)",
+      "Read(**/.env.*)",
+      "Read(**/secrets/**)",
+      "Read(**/bin/)",
+      "Read(**/obj/)"
+    ]
+  }
+}


### PR DESCRIPTION
This commit adds guidelines/restrictions for .claude specifically so that it does not read our secrets