### PR TITLE
chore: stop containers when devcontainer stops

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -19,6 +19,7 @@ services:
 
   db:
     image: postgres:17
+    container_name: tavern-db
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data/
@@ -61,6 +62,7 @@ services:
 
   ngrok:
     image: ngrok/ngrok:latest
+    container_name: tavern-ngrok
     restart: unless-stopped
     entrypoint:
       - /bin/sh

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -27,7 +27,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_DB: postgres
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -41,8 +41,8 @@ services:
     container_name: tavern-mailpit
     restart: unless-stopped
     ports:
-      - "8025:8025"
-      - "1025:1025"
+      - "127.0.0.1:8025:8025"
+      - "127.0.0.1:1025:1025"
     networks:
       - tavern-net
 
@@ -51,7 +51,7 @@ services:
     container_name: tavern-localstack
     restart: unless-stopped
     ports:
-      - "4566:4566"
+      - "127.0.0.1:4566:4566"
     environment:
       - SERVICES=s3
     volumes:
@@ -73,7 +73,7 @@ services:
           exec ngrok http devcontainer:8080
         fi
     ports:
-      - "4040:4040" 
+      - "127.0.0.1:4040:4040" 
     environment:
       - NGROK_AUTHTOKEN=${NGROK_AUTHTOKEN}
     networks:
@@ -102,7 +102,7 @@ services:
       - ./keycloak-themes:/opt/keycloak/themes
       - ./keycloak-plugins:/opt/keycloak/providers
     ports:
-      - "8082:8080"
+      - "127.0.0.1:8082:8080"
     networks:
       - tavern-net
     depends_on:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
     "dockerComposeFile": "compose.yaml",
     "service": "devcontainer",
     "workspaceFolder": "/workspaces",
+    "shutdownAction": "stopCompose",
 
     "remoteEnv": {
         "DOTNET_ENVIRONMENT": "Development"


### PR DESCRIPTION
This stops all containers related to the devcontainer so they don't linger and automatically restart when your system starts, and does not expose all ports to your LAN.